### PR TITLE
Changed node module bcrypt to bcryptjs

### DIFF
--- a/node_modules_local/chat-server/chat-server.js
+++ b/node_modules_local/chat-server/chat-server.js
@@ -405,7 +405,7 @@ ChatServer.prototype.removeSocketFromAllRooms = function (socket, user) {
  */
 ChatServer.prototype.createRoom = function (socket, password) {
     var _this = this,
-        bcrypt = require('bcrypt'),
+        bcrypt = require('bcryptjs'),
         saltRounds = 10,
         name = _this.generateRoomName(6);
 
@@ -447,7 +447,7 @@ ChatServer.prototype.createRoom = function (socket, password) {
  * @returns {boolean}
  */
 ChatServer.prototype.isRoomPasswordValid = function (password, hash) {
-    var bcrypt = require('bcrypt');
+    var bcrypt = require('bcryptjs');
 
     return bcrypt.compareSync(password, hash);
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-    "bcrypt": "^0.8.6",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "ioredis": "^1.15.1",


### PR DESCRIPTION
Since CentOS has issues with node-gyp compilation we decided to switch to `bcryptjs` package because it doesn't have such requirements and has same API.